### PR TITLE
Add TZLabel instances for Data, Typeable, GHC Generic, NFData.

### DIFF
--- a/Data/Time/Zones/DB.hs.template
+++ b/Data/Time/Zones/DB.hs.template
@@ -7,6 +7,9 @@ Maintainer  : Mihaly Barasz <klao@nilcons.com>
 Stability   : experimental
 -}
 
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+
 module Data.Time.Zones.DB (
   toTZName,
   fromTZName,
@@ -19,16 +22,22 @@ module Data.Time.Zones.DB (
   tzDescriptions,
   ) where
 
+import           Control.DeepSeq (NFData, rnf)
 import qualified Data.ByteString.Char8 as BS
 import qualified Data.ByteString.Lazy.Char8 as BL
 import qualified Data.Map.Lazy as M
+import           Data.Data (Data, Typeable)
 import qualified Data.Vector as V
+import           GHC.Generics (Generic)
 
 {-# ANN module "HLint: ignore Use camelCase" #-}
 -- | Enumeration of time zone locations.
 data TZLabel
   TZ_LABEL_DECL
-  deriving (Eq,Ord,Enum,Bounded,Show,Read)
+  deriving (Eq,Ord,Enum,Bounded,Show,Read,Data,Typeable,Generic)
+
+instance NFData TZLabel where
+  rnf = (`seq` ())
 
 -- | Type of the elements of the compiled-in time zone info database.
 --

--- a/tzdata.cabal
+++ b/tzdata.cabal
@@ -52,6 +52,7 @@ Library
     base               >= 4        && < 5,
     bytestring         >= 0.9      && < 0.11,
     containers         >= 0.5      && < 0.6,
+    deepseq            >= 1.1      && < 1.5,
     vector             >= 0.9      && < 0.11
 
 Test-Suite test-db


### PR DESCRIPTION
`NFData` comes from the `deepseq` package which is already a transitional dependency.

This makes it easy to include `TZLabel` in larger record types that want to provide themselves instances for these classes. Otherwise one has to write orphan instances for `TZLabel`.  
