### PR TITLE
Allow vector-0.12

### DIFF
--- a/tzdata.cabal
+++ b/tzdata.cabal
@@ -53,7 +53,7 @@ Library
     bytestring         >= 0.9      && < 0.11,
     containers         >= 0.5      && < 0.6,
     deepseq            >= 1.1      && < 1.5,
-    vector             >= 0.9      && < 0.12
+    vector             >= 0.9      && < 0.13
 
 Test-Suite test-db
   Default-Language: Haskell2010


### PR DESCRIPTION
Would be nice to propagate to `tz` as well.