### PR TITLE
Avoid MissingH, allow bytestring v0.11

### DIFF
--- a/tools/genZones.hs
+++ b/tools/genZones.hs
@@ -3,14 +3,35 @@ import Control.Monad hiding (join)
 import qualified Data.ByteString.Lazy.Char8 as BL
 import Data.Function (on)
 import Data.List
+import Data.List.Split (splitOn)
 import Data.Maybe
-import Data.String.Utils (replace, join)
 import System.Directory
 import System.FilePath.Find
 import System.Environment
 
 -- Suppress 'redundant import' warning:
 import Prelude
+
+-- The following list functions were copied from MissingH, written by John Goerzen.
+-- The library is unmaintained, see https://github.com/haskell-hvr/missingh/issues/54
+-- It is BSD-3-Clause licensed.
+-- They were modified to use 'splitOn' from the 'split' package.
+
+{- | Given a list and a replacement list, replaces each occurance of the search
+list with the replacement list in the operation list.
+Example:
+>replace "," "." "127,0,0,1" -> "127.0.0.1"
+-}
+replace :: Eq a => [a] -> [a] -> [a] -> [a]
+replace old new = join new . splitOn old
+
+{- | Given a delimiter and a list of items (or strings), join the items
+by using the delimiter.
+Example:
+> join "|" ["foo", "bar", "baz"] -> "foo|bar|baz"
+-}
+join :: [a] -> [[a]] -> [a]
+join delim = concat . intersperse delim
 
 data TZFile
   = Reg String FilePath

--- a/tools/tzdata-tools.cabal
+++ b/tools/tzdata-tools.cabal
@@ -18,4 +18,4 @@ Executable genZones
     directory,
     filemanip,
     filepath,
-    MissingH
+    split

--- a/tzdata.cabal
+++ b/tzdata.cabal
@@ -55,7 +55,7 @@ Library
   GHC-Options: -Wall
   Build-Depends:
     base               >= 4        && < 5,
-    bytestring         >= 0.9      && < 0.11,
+    bytestring         >= 0.9      && < 0.12,
     containers         >= 0.5      && < 0.7,
     deepseq            >= 1.1      && < 1.5,
     vector             >= 0.9      && < 0.13


### PR DESCRIPTION
These are two changes that enable using tzdata on the GHC 9.2 series.

The MissingH library [is unmaintained](https://github.com/haskell-hvr/missingh/issues/54) and should be [avoided according to Hackage trustees](https://github.com/haskell-infra/hackage-trustees/issues/306#issuecomment-864476486). So I copied the definition of the required function. It is a one-liner and arguably not copyrightable, but I still credited the original author, John Goerzen.

The other change is allowing bytestring version 0.11. The bytestring 0.10 series excludes base 4.16, which GHC 9.2 specifies. So the dependency is simply bumped.

I have tested using `USE_CABAL=YES ./build-tzdata.sh` in a shell, which seemed to pass without issue.