### PR TITLE
Port tests to the Tasty ecosystem

### DIFF
--- a/tests/testDB.hs
+++ b/tests/testDB.hs
@@ -6,9 +6,8 @@ import qualified Data.ByteString.Lazy.Char8 as BL
 import Data.Maybe
 import Data.Time.Zones.DB
 import Data.Time.Zones.Files
-import Test.Framework.Providers.HUnit
-import Test.Framework.TH
-import Test.HUnit hiding (Test)
+import Test.Tasty.HUnit
+import Test.Tasty.TH
 import System.Posix.Env
 
 case_Budapest_is_Budapest :: IO ()

--- a/tzdata.cabal
+++ b/tzdata.cabal
@@ -72,9 +72,9 @@ Test-Suite test-db
   Build-Depends:
     tzdata,
     base                       >= 4       && < 5,
-    bytestring                 >= 0.9     && < 0.11,
+    bytestring                 >= 0.9     && < 0.12,
     HUnit                      >= 1.2     && < 1.7,
-    test-framework             >= 0.4     && < 1,
-    test-framework-hunit       >= 0.2     && < 0.4,
-    test-framework-th          >= 0.2     && < 0.4,
+    tasty,
+    tasty-hunit,
+    tasty-th,
     unix                       >= 2.6     && < 3


### PR DESCRIPTION
The [test-framework](https://github.com/haskell-infra/hackage-trustees/issues/323#issuecomment-980729413) ecosystem doesn't work since GHC 8.10. This PR ports the tests to the Tasty ecosystem which has a similar API. The test suite passed with GHC 9.2.1 and cabal-install 3.6.2.0.